### PR TITLE
feat(api): initialize ElysiaJS backend with Bun, Swagger and Eden Treaty (#41)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,8 +11,12 @@
     "lint": "eslint \"src/**/*.ts*\""
   },
   "dependencies": {
+    "@elysiajs/cors": "1.1.1",
+    "@elysiajs/swagger": "1.1.5",
     "@pizzaconstructor/shared": "workspace:*",
-    "@pizzaconstructor/theme": "workspace:*"
+    "@pizzaconstructor/theme": "workspace:*",
+    "@sinclair/typebox": "0.32.34",
+    "elysia": "1.1.24"
   },
   "devDependencies": {
     "@pizzaconstructor/typescript-config": "workspace:*",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,20 +1,48 @@
-import { PIZZA_SIZES } from "@pizzaconstructor/shared";
-import { colors } from "@pizzaconstructor/theme";
+import { Elysia } from "elysia";
+import { swagger } from "@elysiajs/swagger";
+import { cors } from "@elysiajs/cors";
+import { healthRoute } from "./routes/health";
 
-const server = Bun.serve({
-  port: process.env.PORT ? parseInt(process.env.PORT) : 3001,
-  fetch(req) {
-    const url = new URL(req.url);
-    if (url.pathname === "/health") {
-      return Response.json({
-        status: "ok",
-        theme: colors.primary.DEFAULT,
-        sizesCount: Object.keys(PIZZA_SIZES).length,
-        timestamp: new Date().toISOString(),
-      });
-    }
-    return new Response("PizzaConstructor API Service");
-  },
-});
+const PORT = process.env.PORT ? parseInt(process.env.PORT) : 3001;
 
-console.log(`🍕 PizzaConstructor API running on http://localhost:${server.port}`);
+export const app = new Elysia()
+  .use(
+    cors({
+      origin: true,
+      methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+      credentials: true,
+    })
+  )
+  .use(
+    swagger({
+      path: "/swagger",
+      documentation: {
+        info: {
+          title: "🍕 PizzaConstructor API",
+          version: "2.0.0",
+          description:
+            "High-performance REST & Real-time WebSocket API powered by ElysiaJS and Bun runtime for custom pizza building and collaborative group orders.",
+        },
+        tags: [
+          { name: "Health & System", description: "Health checks and operational diagnostics" },
+          { name: "Catalog", description: "Product catalog and ingredients" },
+          { name: "Constructor", description: "Interactive custom pizza calculation engine" },
+          { name: "Group Orders", description: "Real-time collaborative order room sessions" },
+        ],
+      },
+    })
+  )
+  .use(healthRoute)
+  .get("/", () => ({
+    message: "🍕 Welcome to PizzaConstructor API Service",
+    documentation: "/swagger",
+    healthCheck: "/health",
+    version: "2.0.0",
+  }))
+  .listen(PORT);
+
+console.log(
+  `🍕 PizzaConstructor API is running at http://${app.server?.hostname}:${app.server?.port} (Swagger docs: http://localhost:${PORT}/swagger)`
+);
+
+export type App = typeof app;

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,0 +1,50 @@
+import { Elysia, t } from "elysia";
+import { PIZZA_SIZES, DOUGH_TYPES, CATEGORIES } from "@pizzaconstructor/shared";
+import { colors } from "@pizzaconstructor/theme";
+
+export const healthRoute = new Elysia({ prefix: "/health" }).get(
+  "/",
+  () => {
+    return {
+      status: "ok" as const,
+      service: "pizzaconstructor-api",
+      version: "2.0.0",
+      uptimeSeconds: process.uptime(),
+      timestamp: new Date().toISOString(),
+      environment: process.env.NODE_ENV ?? "development",
+      theme: {
+        primaryColor: colors.primary.DEFAULT,
+        slateColor: colors.slate.DEFAULT,
+      },
+      stats: {
+        sizesCount: Object.keys(PIZZA_SIZES).length,
+        doughTypesCount: Object.keys(DOUGH_TYPES).length,
+        categoriesCount: CATEGORIES.length,
+      },
+    };
+  },
+  {
+    response: t.Object({
+      status: t.Literal("ok"),
+      service: t.String(),
+      version: t.String(),
+      uptimeSeconds: t.Number(),
+      timestamp: t.String(),
+      environment: t.String(),
+      theme: t.Object({
+        primaryColor: t.String(),
+        slateColor: t.String(),
+      }),
+      stats: t.Object({
+        sizesCount: t.Number(),
+        doughTypesCount: t.Number(),
+        categoriesCount: t.Number(),
+      }),
+    }),
+    detail: {
+      tags: ["Health & System"],
+      summary: "System health check",
+      description: "Returns service uptime, operational health, and domain readiness stats.",
+    },
+  }
+);

--- a/bun.lock
+++ b/bun.lock
@@ -42,8 +42,12 @@
       "name": "@pizzaconstructor/api",
       "version": "0.1.0",
       "dependencies": {
+        "@elysiajs/cors": "1.1.1",
+        "@elysiajs/swagger": "1.1.5",
         "@pizzaconstructor/shared": "workspace:*",
         "@pizzaconstructor/theme": "workspace:*",
+        "@sinclair/typebox": "0.32.34",
+        "elysia": "1.1.24",
       },
       "devDependencies": {
         "@pizzaconstructor/eslint-config": "workspace:*",
@@ -118,6 +122,10 @@
     },
   },
   "packages": {
+    "@elysiajs/cors": ["@elysiajs/cors@1.1.1", "", { "peerDependencies": { "elysia": ">= 1.1.0" } }, "sha512-Bl6JSURwbneaJqkq02bd0C/F8StkmU5zoPLpnSncy4DZSU8TDwWPXxmoHqozI3hf1piDaSQ+I21cmpjPlQ8uYQ=="],
+
+    "@elysiajs/swagger": ["@elysiajs/swagger@1.1.5", "", { "dependencies": { "@scalar/types": "^0.0.12", "openapi-types": "^12.1.3", "pathe": "^1.1.2" }, "peerDependencies": { "elysia": ">= 1.1.0" } }, "sha512-B+lzODhQ6lAMlBHMzf5QcniMCdw5b6dE8D5j4eTrzcgg4cm/jtOh6bYOUL1QHZJt4Zf/v5GvzzF/tJLHAFBq1Q=="],
+
     "@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.10.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg=="],
@@ -274,6 +282,12 @@
 
     "@pizzaconstructor/web": ["@pizzaconstructor/web@workspace:apps/web"],
 
+    "@scalar/openapi-types": ["@scalar/openapi-types@0.1.1", "", {}, "sha512-NMy3QNk6ytcCoPUGJH0t4NNr36OWXgZhA3ormr3TvhX1NDgoF95wFyodGVH8xiHeUyn2/FxtETm8UBLbB5xEmg=="],
+
+    "@scalar/types": ["@scalar/types@0.0.12", "", { "dependencies": { "@scalar/openapi-types": "0.1.1", "@unhead/schema": "^1.9.5" } }, "sha512-XYZ36lSEx87i4gDqopQlGCOkdIITHHEvgkuJFrXFATQs9zHARop0PN0g4RZYWj+ZpCUclOcaOjbCt8JGe22mnQ=="],
+
+    "@sinclair/typebox": ["@sinclair/typebox@0.32.34", "", {}, "sha512-a3Z3ytYl6R/+7ldxx04PO1semkwWlX/8pTqxsPw4quIcIXDFPZhOc1Wx8azWmkU26ccK3mHwcWenn0avNgAKQg=="],
+
     "@socket.io/component-emitter": ["@socket.io/component-emitter@3.1.2", "", {}, "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
@@ -329,6 +343,8 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.67.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA=="],
+
+    "@unhead/schema": ["@unhead/schema@1.11.20", "", { "dependencies": { "hookable": "^5.5.3", "zhead": "^2.2.4" } }, "sha512-0zWykKAaJdm+/Y7yi/Yds20PrUK7XabLe9c3IRcjnwYmSWY6z0Cr19VIs3ozCj8P+GhR+/TI2mwtGlueCEYouA=="],
 
     "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
@@ -528,6 +544,8 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.407", "", {}, "sha512-4R8XgQOdfxexCd/u63lRm6wCHjECwI45MV9wxAs2ggtfWe2hwlo1ql97jKsju2IcJ+jFSTwBssyYoiWhh7mauQ=="],
 
+    "elysia": ["elysia@1.1.24", "", { "dependencies": { "@sinclair/typebox": "0.32.34", "cookie": "^1.0.1", "fast-decode-uri-component": "^1.0.1", "openapi-types": "^12.1.3" }, "peerDependencies": { "typescript": ">= 5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-viJOb+PADrxJn7ntlQfoXsLuVgHNS09gn9dj2yroHnwqheN0hZp81WCGRQXkvh4kW5zGISX50/eqAcoNDpdL/g=="],
+
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
@@ -589,6 +607,8 @@
     "faker": ["faker@5.5.3", "", {}, "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="],
 
     "fancy-log": ["fancy-log@1.3.3", "", { "dependencies": { "ansi-gray": "^0.1.1", "color-support": "^1.1.3", "parse-node-version": "^1.0.0", "time-stamp": "^1.0.0" } }, "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw=="],
+
+    "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -695,6 +715,8 @@
     "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "homedir-polyfill": ["homedir-polyfill@1.0.3", "", { "dependencies": { "parse-passwd": "^1.0.0" } }, "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA=="],
+
+    "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -874,6 +896,8 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
+
     "opn": ["opn@5.3.0", "", { "dependencies": { "is-wsl": "^1.1.0" } }, "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
@@ -903,6 +927,8 @@
     "path-root-regex": ["path-root-regex@0.1.2", "", {}, "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ=="],
 
     "path-to-regexp": ["path-to-regexp@0.1.13", "", {}, "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="],
+
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -1160,6 +1186,8 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
+    "zhead": ["zhead@2.2.4", "", {}, "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
@@ -1185,6 +1213,8 @@
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "connect/finalhandler": ["finalhandler@1.1.0", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.1", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.2", "statuses": "~1.3.1", "unpipe": "~1.0.0" } }, "sha512-ejnvM9ZXYzp6PUPUyQBMBf0Co5VX2gr5H2VQe2Ui2jWXNlxv+PYZo8wpAymJNJdLsG1R4p+M4aynF8KuoUEwRw=="],
+
+    "elysia/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 


### PR DESCRIPTION
## Summary of Changes
- Integrated ElysiaJS (`elysia`), `@elysiajs/swagger`, `@elysiajs/cors`, and `@sinclair/typebox` in `apps/api`.
- Created modular typed diagnostic health route `GET /health` in `apps/api/src/routes/health.ts` reporting service uptime, version, theme tokens, and domain sizing metrics.
- Mounted interactive Swagger documentation UI at `/swagger` with domain tags (`Health & System`, `Catalog`, `Constructor`, `Group Orders`).
- Configured CORS middleware supporting all standard HTTP verbs and credentials.
- Exported `export type App = typeof app;` for zero-codegen Eden Treaty RPC client consumption in `apps/web`.

## Connected Work Item
Closes #41

## Verification & Test Results
- `turbo check-types`: 5/5 tasks passed (0 errors)
- `turbo lint`: 5/5 tasks passed (0 errors)
- `turbo build`: 2/2 tasks passed (`apps/api` bundled cleanly into 0.45MB)
- `GET /health`: 200 OK (`{ status: "ok", service: "pizzaconstructor-api", version: "2.0.0", uptimeSeconds: ... }`)
- `GET /swagger/json`: 200 OK (OpenAPI 3.0.3 valid schema)