### PR TITLE
feat(grouporder): implement Elysia WebSocket server for real-time room sessions (#50)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,8 @@ import { cors } from "@elysiajs/cors";
 import { healthRoute } from "./routes/health";
 import { productsRoutes, categoriesRoutes } from "./routes/products";
 import { ingredientsRoutes } from "./routes/ingredients";
+import { groupOrderRoutes } from "./routes/groupOrders";
+import { groupOrderWsRoutes } from "./routes/groupOrderWs";
 import { connectDB } from "./db/connection";
 
 const PORT = process.env.PORT ? parseInt(process.env.PORT) : 3001;
@@ -50,6 +52,8 @@ export const app = new Elysia()
   .use(productsRoutes)
   .use(categoriesRoutes)
   .use(ingredientsRoutes)
+  .use(groupOrderRoutes)
+  .use(groupOrderWsRoutes)
   .get("/", () => ({
     message: "🍕 Welcome to PizzaConstructor API Service",
     documentation: "/swagger",

--- a/apps/api/src/routes/groupOrderWs.ts
+++ b/apps/api/src/routes/groupOrderWs.ts
@@ -1,0 +1,167 @@
+import { Elysia, t } from "elysia";
+import { groupOrderManager } from "../services/groupOrderManager";
+import type {
+  GroupWsMessage,
+  GroupOrderItem,
+  GroupOrderStatus,
+} from "@pizzaconstructor/shared";
+
+export const groupOrderWsRoutes = new Elysia().ws("/ws/group-orders/:roomId", {
+  params: t.Object({
+    roomId: t.String(),
+  }),
+  open(ws) {
+    const roomId = ws.data.params.roomId;
+    const topic = `group-room:${roomId}`;
+    ws.subscribe(topic);
+
+    const room = groupOrderManager.getRoom(roomId);
+    if (room) {
+      ws.send({
+        type: "ROOM_SYNC",
+        roomId,
+        payload: { room },
+      });
+    } else {
+      ws.send({
+        type: "ERROR",
+        roomId,
+        payload: { message: "Room not found" },
+      });
+    }
+  },
+  message(ws, message: unknown) {
+    const roomId = ws.data.params.roomId;
+    const topic = `group-room:${roomId}`;
+
+    try {
+      const msg = (typeof message === "string" ? JSON.parse(message) : message) as GroupWsMessage;
+
+      switch (msg.type) {
+        case "JOIN_ROOM": {
+          const { participantName, avatar } = (msg.payload || {}) as {
+            participantName: string;
+            avatar?: string;
+          };
+          if (!participantName) {
+            ws.send({ type: "ERROR", payload: { message: "Participant name required" } });
+            return;
+          }
+          const res = groupOrderManager.joinRoom(roomId, participantName, avatar);
+          if (res) {
+            // Broadcast full updated room state to all connected room peers
+            ws.publish(topic, {
+              type: "ROOM_SYNC",
+              roomId,
+              payload: { room: res.room, joinedParticipant: res.participant },
+            });
+            ws.send({
+              type: "ROOM_SYNC",
+              roomId,
+              payload: { room: res.room, yourParticipant: res.participant },
+            });
+          }
+          break;
+        }
+
+        case "ADD_ITEM": {
+          const itemInput = (msg.payload || {}) as Omit<GroupOrderItem, "id" | "createdAt">;
+          const res = groupOrderManager.addItem(roomId, itemInput);
+          if (res) {
+            ws.publish(topic, {
+              type: "ROOM_SYNC",
+              roomId,
+              payload: { room: res.room, addedItem: res.item },
+            });
+            ws.send({
+              type: "ROOM_SYNC",
+              roomId,
+              payload: { room: res.room, addedItem: res.item },
+            });
+          }
+          break;
+        }
+
+        case "REMOVE_ITEM": {
+          const { itemId, participantId, hostToken } = (msg.payload || {}) as {
+            itemId: string;
+            participantId?: string;
+            hostToken?: string;
+          };
+          const updatedRoom = groupOrderManager.removeItem(roomId, itemId, participantId, hostToken);
+          if (updatedRoom) {
+            ws.publish(topic, {
+              type: "ROOM_SYNC",
+              roomId,
+              payload: { room: updatedRoom, removedItemId: itemId },
+            });
+            ws.send({
+              type: "ROOM_SYNC",
+              roomId,
+              payload: { room: updatedRoom, removedItemId: itemId },
+            });
+          }
+          break;
+        }
+
+        case "SET_STATUS": {
+          const { status, hostToken } = (msg.payload || {}) as {
+            status: GroupOrderStatus;
+            hostToken?: string;
+          };
+          const updatedRoom = groupOrderManager.setStatus(roomId, status, hostToken);
+          if (updatedRoom) {
+            ws.publish(topic, {
+              type: "ROOM_SYNC",
+              roomId,
+              payload: { room: updatedRoom },
+            });
+            ws.send({
+              type: "ROOM_SYNC",
+              roomId,
+              payload: { room: updatedRoom },
+            });
+          }
+          break;
+        }
+
+        case "LEAVE_ROOM": {
+          const { participantId } = (msg.payload || {}) as { participantId: string };
+          const updatedRoom = groupOrderManager.leaveRoom(roomId, participantId);
+          if (updatedRoom) {
+            ws.publish(topic, {
+              type: "ROOM_SYNC",
+              roomId,
+              payload: { room: updatedRoom },
+            });
+          }
+          break;
+        }
+
+        case "ROOM_SYNC":
+        default: {
+          const room = groupOrderManager.getRoom(roomId);
+          if (room) {
+            ws.send({
+              type: "ROOM_SYNC",
+              roomId,
+              payload: { room },
+            });
+          }
+          break;
+        }
+      }
+    } catch (err: unknown) {
+      const errMsg = err instanceof Error ? err.message : "An unexpected error occurred";
+      ws.send({
+        type: "ERROR",
+        roomId,
+        payload: { message: errMsg },
+      });
+    }
+  },
+  close(ws) {
+    const roomId = ws.data.params.roomId;
+    ws.unsubscribe(`group-room:${roomId}`);
+  },
+});

--- a/apps/api/src/routes/groupOrders.ts
+++ b/apps/api/src/routes/groupOrders.ts
@@ -1,0 +1,86 @@
+import { Elysia, t } from "elysia";
+import { groupOrderManager } from "../services/groupOrderManager";
+
+export const groupOrderRoutes = new Elysia({ prefix: "/api/group-orders" })
+  .get(
+    "/",
+    () => {
+      const rooms = groupOrderManager.getAllRooms().map((r) => ({
+        id: r.id,
+        title: r.title,
+        hostName: r.hostName,
+        status: r.status,
+        deadlineIso: r.deadlineIso,
+        participantsCount: r.participants.length,
+        itemsCount: r.items.length,
+        totalPrice: r.items.reduce((sum, i) => sum + i.unitPrice * i.quantity, 0),
+        createdAt: r.createdAt,
+      }));
+      return { success: true, count: rooms.length, rooms };
+    },
+    {
+      detail: {
+        tags: ["Group Orders"],
+        summary: "List all active group order sessions",
+      },
+    }
+  )
+  .post(
+    "/",
+    ({ body, set }) => {
+      try {
+        const { room, hostToken } = groupOrderManager.createRoom({
+          title: body.title,
+          hostName: body.hostName,
+          deadlineIso: body.deadlineIso,
+          deliveryAddress: body.deliveryAddress,
+          maxParticipants: body.maxParticipants,
+        });
+
+        set.status = 201;
+        return {
+          success: true,
+          roomId: room.id,
+          hostToken,
+          room,
+        };
+      } catch (err: unknown) {
+        set.status = 400;
+        const msg = err instanceof Error ? err.message : "Failed to create group order";
+        return { success: false, error: msg };
+      }
+    },
+    {
+      body: t.Object({
+        title: t.String({ minLength: 2, maxLength: 80 }),
+        hostName: t.String({ minLength: 2, maxLength: 50 }),
+        deadlineIso: t.Optional(t.String()),
+        deliveryAddress: t.Optional(t.String()),
+        maxParticipants: t.Optional(t.Number({ minimum: 2, maximum: 100 })),
+      }),
+      detail: {
+        tags: ["Group Orders"],
+        summary: "Create a new collaborative group order session",
+      },
+    }
+  )
+  .get(
+    "/:id",
+    ({ params, set }) => {
+      const room = groupOrderManager.getRoom(params.id);
+      if (!room) {
+        set.status = 404;
+        return { success: false, error: "Group order room not found" };
+      }
+      return { success: true, room };
+    },
+    {
+      params: t.Object({
+        id: t.String(),
+      }),
+      detail: {
+        tags: ["Group Orders"],
+        summary: "Get full real-time group order room details",
+      },
+    }
+  );

--- a/apps/api/src/services/groupOrderManager.ts
+++ b/apps/api/src/services/groupOrderManager.ts
@@ -1,0 +1,195 @@
+import type {
+  GroupOrderRoom,
+  GroupParticipant,
+  GroupOrderItem,
+  GroupOrderStatus,
+} from "@pizzaconstructor/shared";
+
+class GroupOrderManager {
+  private rooms: Map<string, GroupOrderRoom> = new Map();
+
+  constructor() {
+    // Seed an initial demo group room for testing
+    this.createRoom({
+      title: "Friday Pizza Party 🍕",
+      hostName: "John (Host)",
+      deadlineIso: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(), // 2 hours from now
+      deliveryAddress: "Tech Hub, 5th Floor Lounge",
+    });
+  }
+
+  public createRoom(options: {
+    title: string;
+    hostName: string;
+    deadlineIso?: string;
+    deliveryAddress?: string;
+    maxParticipants?: number;
+    customSlug?: string;
+  }): { room: GroupOrderRoom; hostToken: string } {
+    const slugBase = options.title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .substring(0, 20) || "order";
+    const randomSuffix = Math.floor(1000 + Math.random() * 9000);
+    const roomId = options.customSlug || `${slugBase}-${randomSuffix}`;
+
+    const hostId = `host-${Date.now()}-${Math.random().toString(36).substring(2, 6)}`;
+    const hostToken = `token-${Date.now()}-${Math.random().toString(36).substring(2, 10)}`;
+
+    const hostParticipant: GroupParticipant = {
+      id: hostId,
+      name: options.hostName,
+      isHost: true,
+      joinedAt: new Date().toISOString(),
+    };
+
+    const room: GroupOrderRoom = {
+      id: roomId,
+      title: options.title,
+      hostId,
+      hostName: options.hostName,
+      hostToken,
+      status: "open",
+      deadlineIso: options.deadlineIso,
+      deliveryAddress: options.deliveryAddress,
+      maxParticipants: options.maxParticipants || 30,
+      participants: [hostParticipant],
+      items: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    this.rooms.set(roomId, room);
+    return { room, hostToken };
+  }
+
+  public getRoom(roomId: string): GroupOrderRoom | null {
+    const room = this.rooms.get(roomId);
+    if (!room) return null;
+
+    // Check if expired and automatically lock
+    if (room.status === "open" && room.deadlineIso) {
+      const deadline = new Date(room.deadlineIso).getTime();
+      if (Date.now() > deadline) {
+        room.status = "locked";
+        room.updatedAt = new Date().toISOString();
+      }
+    }
+
+    return room;
+  }
+
+  public joinRoom(
+    roomId: string,
+    participantName: string,
+    avatar?: string
+  ): { room: GroupOrderRoom; participant: GroupParticipant } | null {
+    const room = this.getRoom(roomId);
+    if (!room) return null;
+
+    // Check if participant already exists by name or create new
+    const existing = room.participants.find(
+      (p) => p.name.toLowerCase() === participantName.trim().toLowerCase()
+    );
+    if (existing) {
+      return { room, participant: existing };
+    }
+
+    if (room.maxParticipants && room.participants.length >= room.maxParticipants) {
+      throw new Error("Room has reached maximum participant capacity");
+    }
+
+    const participant: GroupParticipant = {
+      id: `p-${Date.now()}-${Math.random().toString(36).substring(2, 6)}`,
+      name: participantName.trim(),
+      avatar,
+      isHost: false,
+      joinedAt: new Date().toISOString(),
+    };
+
+    room.participants.push(participant);
+    room.updatedAt = new Date().toISOString();
+    return { room, participant };
+  }
+
+  public leaveRoom(roomId: string, participantId: string): GroupOrderRoom | null {
+    const room = this.getRoom(roomId);
+    if (!room) return null;
+
+    room.participants = room.participants.filter((p) => p.id !== participantId);
+    room.items = room.items.filter((i) => i.participantId !== participantId);
+    room.updatedAt = new Date().toISOString();
+    return room;
+  }
+
+  public addItem(
+    roomId: string,
+    itemInput: Omit<GroupOrderItem, "id" | "createdAt">
+  ): { room: GroupOrderRoom; item: GroupOrderItem } | null {
+    const room = this.getRoom(roomId);
+    if (!room) return null;
+
+    if (room.status !== "open") {
+      throw new Error(`Cannot add items: Room is ${room.status}`);
+    }
+
+    const item: GroupOrderItem = {
+      ...itemInput,
+      id: `item-${Date.now()}-${Math.random().toString(36).substring(2, 6)}`,
+      createdAt: new Date().toISOString(),
+    };
+
+    room.items.push(item);
+    room.updatedAt = new Date().toISOString();
+    return { room, item };
+  }
+
+  public removeItem(
+    roomId: string,
+    itemId: string,
+    requesterParticipantId?: string,
+    hostToken?: string
+  ): GroupOrderRoom | null {
+    const room = this.getRoom(roomId);
+    if (!room) return null;
+
+    const itemIndex = room.items.findIndex((i) => i.id === itemId);
+    const item = room.items[itemIndex];
+    if (!item) return room;
+
+    const isOwner = requesterParticipantId && item.participantId === requesterParticipantId;
+    const isHost = hostToken && room.hostToken === hostToken;
+
+    if (!isOwner && !isHost) {
+      throw new Error("Unauthorized to remove this item");
+    }
+
+    room.items.splice(itemIndex, 1);
+    room.updatedAt = new Date().toISOString();
+    return room;
+  }
+
+  public setStatus(
+    roomId: string,
+    status: GroupOrderStatus,
+    hostToken?: string
+  ): GroupOrderRoom | null {
+    const room = this.getRoom(roomId);
+    if (!room) return null;
+
+    if (hostToken && room.hostToken !== hostToken) {
+      throw new Error("Invalid host token");
+    }
+
+    room.status = status;
+    room.updatedAt = new Date().toISOString();
+    return room;
+  }
+
+  public getAllRooms(): GroupOrderRoom[] {
+    return Array.from(this.rooms.values());
+  }
+}
+
+export const groupOrderManager = new GroupOrderManager();

--- a/apps/api/test/groupOrder.test.ts
+++ b/apps/api/test/groupOrder.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+import { groupOrderManager } from "../src/services/groupOrderManager";
+import { app } from "../src/index";
+
+describe("Group Order Management & REST API", () => {
+  it("creates a new collaborative group room with host participant", () => {
+    const { room, hostToken } = groupOrderManager.createRoom({
+      title: "Team Pizza Lunch",
+      hostName: "Alice Host",
+      deliveryAddress: "Building A, Room 302",
+      maxParticipants: 10,
+    });
+
+    expect(room.id).toBeDefined();
+    expect(room.title).toBe("Team Pizza Lunch");
+    expect(room.status).toBe("open");
+    expect(room.participants.length).toBe(1);
+    expect(room.participants[0].name).toBe("Alice Host");
+    expect(room.participants[0].isHost).toBe(true);
+    expect(hostToken).toBeDefined();
+  });
+
+  it("allows other participants to join the group room", () => {
+    const { room } = groupOrderManager.createRoom({
+      title: "Design Team Dinner",
+      hostName: "Bob Host",
+    });
+
+    const joinRes = groupOrderManager.joinRoom(room.id, "Charlie Guest");
+    expect(joinRes).not.toBeNull();
+    expect(joinRes?.participant.name).toBe("Charlie Guest");
+    expect(joinRes?.participant.isHost).toBe(false);
+
+    const updatedRoom = groupOrderManager.getRoom(room.id);
+    expect(updatedRoom?.participants.length).toBe(2);
+  });
+
+  it("allows participants to add items to the group cart", () => {
+    const { room } = groupOrderManager.createRoom({
+      title: "Dev Team Gathering",
+      hostName: "Dave",
+    });
+
+    const joinRes = groupOrderManager.joinRoom(room.id, "Eve");
+    const eveId = joinRes?.participant.id || "";
+
+    const addRes = groupOrderManager.addItem(room.id, {
+      participantId: eveId,
+      participantName: "Eve",
+      name: "Pepperoni Passion",
+      sizeLabel: "30cm",
+      unitPrice: 16.5,
+      quantity: 1,
+      weightG: 650,
+      allergens: ["Gluten"],
+    });
+
+    expect(addRes).not.toBeNull();
+    expect(addRes?.room.items.length).toBe(1);
+    expect(addRes?.item.name).toBe("Pepperoni Passion");
+  });
+
+  it("allows host to set room status to locked", () => {
+    const { room, hostToken } = groupOrderManager.createRoom({
+      title: "Sprint Review Feast",
+      hostName: "Frank",
+    });
+
+    const lockedRoom = groupOrderManager.setStatus(room.id, "locked", hostToken);
+    expect(lockedRoom?.status).toBe("locked");
+
+    // Adding items when room is locked throws error
+    expect(() => {
+      groupOrderManager.addItem(room.id, {
+        participantId: "any",
+        participantName: "Guest",
+        name: "Test",
+        sizeLabel: "30cm",
+        unitPrice: 10,
+        quantity: 1,
+        weightG: 500,
+        allergens: [],
+      });
+    }).toThrow();
+  });
+
+  it("handles GET /api/group-orders via HTTP", async () => {
+    const response = await app.handle(new Request("http://localhost/api/group-orders"));
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as { success: boolean; rooms: unknown[] };
+    expect(body.success).toBe(true);
+    expect(Array.isArray(body.rooms)).toBe(true);
+  });
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -55,14 +55,66 @@ export interface CustomPizzaRecipe {
   allergens: string[];
 }
 
-export interface GroupOrderSession {
+// ---------------------------------------------
+// Group Orders Domain Models
+// ---------------------------------------------
+export type GroupOrderStatus = "open" | "locked" | "submitted" | "completed" | "cancelled";
+
+export interface GroupParticipant {
   id: string;
-  code: string;
-  hostName: string;
-  hostUserId?: string;
+  name: string;
+  avatar?: string;
+  isHost: boolean;
+  joinedAt: string;
+}
+
+export interface GroupOrderItem {
+  id: string;
+  participantId: string;
+  participantName: string;
+  name: string;
+  sizeLabel: string;
+  unitPrice: number;
+  quantity: number;
+  weightG: number;
+  allergens: string[];
+  customDetails?: {
+    size: PizzaSizeId;
+    dough: DoughTypeId;
+    sauceNames: string[];
+    toppingNames: string[];
+  };
+  createdAt: string;
+}
+
+export interface GroupOrderRoom {
+  id: string; // URL slug e.g. "team-lunch-847" or uuid
   title: string;
-  deadline: string; // ISO String
-  status: "open" | "locked" | "submitted" | "completed" | "cancelled";
-  participantsCount: number;
-  totalAmount: number;
+  hostId: string;
+  hostName: string;
+  hostToken: string; // Secret token for host controls
+  status: GroupOrderStatus;
+  deadlineIso?: string;
+  deliveryAddress?: string;
+  maxParticipants?: number;
+  participants: GroupParticipant[];
+  items: GroupOrderItem[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type GroupWsMessageType =
+  | "JOIN_ROOM"
+  | "LEAVE_ROOM"
+  | "ADD_ITEM"
+  | "REMOVE_ITEM"
+  | "SET_STATUS"
+  | "ROOM_SYNC"
+  | "ERROR";
+
+export interface GroupWsMessage {
+  type: GroupWsMessageType;
+  payload?: unknown;
+  roomId?: string;
+  participantId?: string;
 }


### PR DESCRIPTION
## Summary of Changes
- Extended domain models in `packages/shared/src/types.ts` for collaborative group orders (`GroupOrderRoom`, `GroupParticipant`, `GroupOrderItem`, `GroupWsMessage`).
- Built thread-safe session manager `GroupOrderManager` in `apps/api/src/services/groupOrderManager.ts`.
- Created REST endpoints in `apps/api/src/routes/groupOrders.ts` (`POST /api/group-orders`, `GET /api/group-orders`, `GET /api/group-orders/:id`).
- Implemented real-time Elysia WebSocket endpoint `/ws/group-orders/:roomId` with Bun pub/sub topic broadcasting (`group-room:${roomId}`).
- Created unit and integration test suite in `apps/api/test/groupOrder.test.ts` (100% passing).

## Connected Work Item
Closes #50

## Verification & Test Results
- `bun test --cwd apps/api`: 10/10 tests passed (44 assertions, 0 failures)
- `turbo check-types`: 5/5 tasks passed (0 errors)
- `turbo lint`: 5/5 tasks passed (0 errors)
- `turbo build`: 2/2 tasks passed (`apps/api` and `apps/web` compiled cleanly)