### PR TITLE
feat(grouporder): build collaborative group order room UI and host controls (#51)

### DIFF
--- a/apps/web/src/app/group-order/[slug]/page.tsx
+++ b/apps/web/src/app/group-order/[slug]/page.tsx
@@ -1,0 +1,505 @@
+"use client";
+
+import * as React from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  Users,
+  Clock,
+  Copy,
+  Check,
+  Lock,
+  Unlock,
+  Trash2,
+  Plus,
+  ShoppingBag,
+  Sparkles,
+  ArrowRight,
+  User,
+} from "lucide-react";
+import { Button } from "@pizzaconstructor/ui";
+import { useGroupOrderWs } from "@/hooks/useGroupOrderWs";
+
+const QUICK_MENU_ITEMS = [
+  { name: "Margherita Artisan", size: "30cm (650gr)", price: 12.99, weightG: 650, allergens: ["Gluten", "Lactose"] },
+  { name: "Pepperoni Passion", size: "30cm (650gr)", price: 15.49, weightG: 680, allergens: ["Gluten", "Lactose"] },
+  { name: "Quattro Formaggi", size: "30cm (650gr)", price: 16.99, weightG: 700, allergens: ["Gluten", "Lactose"] },
+  { name: "Vegan Garden Fiesta", size: "30cm (650gr)", price: 14.50, weightG: 620, allergens: ["Gluten"] },
+  { name: "Mediterranean Prosciutto", size: "35cm (800gr)", price: 18.99, weightG: 800, allergens: ["Gluten", "Lactose"] },
+];
+
+export default function GroupOrderRoomPage() {
+  const params = useParams();
+  const router = useRouter();
+  const roomId = (params?.slug as string) || "";
+
+  const {
+    room,
+    currentParticipant,
+    isConnected,
+    isHost,
+    joinRoom,
+    addItem,
+    removeItem,
+    setStatus,
+  } = useGroupOrderWs(roomId);
+
+  const [joinName, setJoinName] = React.useState("");
+  const [copiedLink, setCopiedLink] = React.useState(false);
+  const [isQuickAddOpen, setIsQuickAddOpen] = React.useState(false);
+  const [timeLeft, setTimeLeft] = React.useState<string>("");
+  const [isUrgent, setIsUrgent] = React.useState<boolean>(false);
+
+  // Live countdown timer calculation
+  React.useEffect(() => {
+    if (!room?.deadlineIso) {
+      setTimeLeft("No Deadline");
+      return;
+    }
+
+    const interval = setInterval(() => {
+      const diff = new Date(room.deadlineIso!).getTime() - Date.now();
+      if (diff <= 0) {
+        setTimeLeft("Expired / Locked");
+        setIsUrgent(true);
+        clearInterval(interval);
+      } else {
+        const mins = Math.floor(diff / 60000);
+        const secs = Math.floor((diff % 60000) / 1000);
+        setTimeLeft(`${mins}m ${secs < 10 ? "0" : ""}${secs}s remaining`);
+        setIsUrgent(mins < 5);
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [room?.deadlineIso]);
+
+  const handleCopyLink = () => {
+    if (typeof window === "undefined") return;
+    navigator.clipboard.writeText(window.location.href);
+    setCopiedLink(true);
+    setTimeout(() => setCopiedLink(false), 2000);
+  };
+
+  const handleJoinSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!joinName.trim()) return;
+    joinRoom(joinName.trim());
+  };
+
+  const handleQuickAdd = (item: (typeof QUICK_MENU_ITEMS)[0]) => {
+    addItem({
+      name: item.name,
+      sizeLabel: item.size,
+      unitPrice: item.price,
+      quantity: 1,
+      weightG: item.weightG,
+      allergens: item.allergens,
+    });
+    setIsQuickAddOpen(false);
+  };
+
+  const totalGroupPrice = room?.items.reduce((sum, i) => sum + i.unitPrice * i.quantity, 0) || 0;
+  const totalGroupCount = room?.items.reduce((sum, i) => sum + i.quantity, 0) || 0;
+
+  // Group items by participant
+  const itemsByParticipant = React.useMemo(() => {
+    if (!room) return {};
+    const map: Record<string, typeof room.items> = {};
+    for (const item of room.items) {
+      const list = map[item.participantName] ?? [];
+      list.push(item);
+      map[item.participantName] = list;
+    }
+    return map;
+  }, [room]);
+
+  return (
+    <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12 flex-1 w-full space-y-8">
+      {/* Join Room Modal Overlay (if not joined yet) */}
+      {!currentParticipant && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80 backdrop-blur-md">
+          <div className="bg-[#1a252f] border border-[#34495e] rounded-3xl p-6 sm:p-8 max-w-md w-full shadow-2xl space-y-5 text-center">
+            <div className="w-16 h-16 rounded-full bg-[#f39c12]/20 border border-[#f39c12] flex items-center justify-center text-3xl mx-auto">
+              🍕
+            </div>
+            <div>
+              <h2 className="text-2xl font-bold text-[#ecf0f1] font-display">
+                Join Group Order
+              </h2>
+              <p className="text-xs text-[#95a5a6] mt-1">
+                You were invited to &ldquo;{room?.title || "Team Pizza Feast"}&rdquo;. Enter your name to add items to the group cart.
+              </p>
+            </div>
+
+            <form onSubmit={handleJoinSubmit} className="space-y-4 text-left">
+              <div className="space-y-1.5">
+                <label className="text-xs font-bold text-[#7f8c8d] uppercase tracking-wider flex items-center space-x-1">
+                  <User className="w-3.5 h-3.5" />
+                  <span>Your Display Name</span>
+                </label>
+                <input
+                  type="text"
+                  required
+                  value={joinName}
+                  onChange={(e) => setJoinName(e.target.value)}
+                  placeholder="E.g., Alex"
+                  className="w-full px-4 py-3 rounded-xl bg-[#0f171e] border border-[#34495e] text-sm font-semibold text-[#ecf0f1] focus:outline-none focus:border-[#f39c12]"
+                />
+              </div>
+
+              <Button
+                type="submit"
+                variant="primary"
+                size="lg"
+                className="w-full font-extrabold text-sm shadow-xl shadow-[#f39c12]/20"
+              >
+                <span>Enter Room & Start Ordering</span>
+                <ArrowRight className="w-4 h-4 ml-1.5" />
+              </Button>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Top Banner: Title, Status, Timer & Shareable Link */}
+      <div className="bg-[#1a252f] border border-[#34495e]/80 rounded-3xl p-6 sm:p-8 shadow-2xl space-y-6">
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 border-b border-[#34495e]/60 pb-6">
+          <div className="space-y-1">
+            <div className="flex items-center space-x-2.5">
+              <span
+                className={`px-2.5 py-0.5 rounded-full text-[10px] font-extrabold uppercase tracking-wider border ${
+                  room?.status === "open"
+                    ? "bg-[#27ae60]/15 text-[#27ae60] border-[#27ae60]/30"
+                    : "bg-[#e74c3c]/15 text-[#e74c3c] border-[#e74c3c]/30"
+                }`}
+              >
+                {room?.status || "Connecting"}
+              </span>
+
+              <span className="text-xs text-[#7f8c8d]">
+                Host: <strong className="text-[#ecf0f1]">{room?.hostName || "Loading..."}</strong>
+              </span>
+
+              {isHost && (
+                <span className="px-2 py-0.5 rounded bg-[#f39c12] text-[#0f171e] text-[10px] font-black uppercase">
+                  You are Host
+                </span>
+              )}
+            </div>
+
+            <h1 className="text-2xl sm:text-3xl font-extrabold text-[#ecf0f1] font-display">
+              {room?.title || "Collaborative Group Room"}
+            </h1>
+            {room?.deliveryAddress && (
+              <p className="text-xs text-[#95a5a6]">
+                📍 Delivery to: {room.deliveryAddress}
+              </p>
+            )}
+          </div>
+
+          {/* Countdown Timer & Copy Link */}
+          <div className="flex flex-wrap items-center gap-3">
+            {room?.deadlineIso && (
+              <div
+                className={`px-3.5 py-2 rounded-2xl border flex items-center space-x-2 text-xs font-bold ${
+                  isUrgent
+                    ? "bg-[#e74c3c]/15 border-[#e74c3c]/40 text-[#e74c3c] animate-pulse"
+                    : "bg-[#0f171e] border-[#34495e] text-[#f39c12]"
+                }`}
+              >
+                <Clock className="w-4 h-4" />
+                <span>{timeLeft}</span>
+              </div>
+            )}
+
+            <Button
+              variant="outline"
+              size="md"
+              onClick={handleCopyLink}
+              className="text-xs flex items-center space-x-1.5 border-[#34495e]"
+            >
+              {copiedLink ? (
+                <>
+                  <Check className="w-3.5 h-3.5 text-[#27ae60]" />
+                  <span>Link Copied!</span>
+                </>
+              ) : (
+                <>
+                  <Copy className="w-3.5 h-3.5 text-[#f39c12]" />
+                  <span>Invite Friends</span>
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+
+        {/* Participants Roster Bar */}
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div className="flex items-center space-x-2">
+            <Users className="w-4 h-4 text-[#f39c12]" />
+            <span className="text-xs font-bold text-[#7f8c8d] uppercase tracking-wider">
+              Participants ({room?.participants.length || 0}):
+            </span>
+            <div className="flex flex-wrap gap-1.5">
+              {room?.participants.map((p) => (
+                <span
+                  key={p.id}
+                  className={`px-2.5 py-1 rounded-xl text-xs font-bold border flex items-center space-x-1.5 ${
+                    p.id === currentParticipant?.id
+                      ? "bg-[#f39c12]/20 border-[#f39c12] text-[#f39c12]"
+                      : "bg-[#0f171e] border-[#34495e] text-[#ecf0f1]"
+                  }`}
+                >
+                  <span>{p.name}</span>
+                  {p.isHost && (
+                    <span className="text-[9px] px-1 rounded bg-[#f39c12] text-[#0f171e] font-extrabold">
+                      Host
+                    </span>
+                  )}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex items-center space-x-1.5 text-xs text-[#7f8c8d]">
+            <span
+              className={`w-2 h-2 rounded-full ${
+                isConnected ? "bg-[#27ae60] shadow-[0_0_6px_#27ae60]" : "bg-[#e74c3c]"
+              }`}
+            />
+            <span>{isConnected ? "Real-time Live Sync" : "Reconnecting..."}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Main Order Stream Grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 items-start">
+        {/* LEFT COLUMN: Collaborative Carts Stream */}
+        <div className="lg:col-span-8 space-y-6">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-bold text-[#ecf0f1] font-display">
+              Group Order Items ({totalGroupCount})
+            </h2>
+
+            {room?.status === "open" && (
+              <div className="flex items-center space-x-2">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() => setIsQuickAddOpen(true)}
+                  className="text-xs font-bold"
+                >
+                  <Plus className="w-3.5 h-3.5 mr-1" />
+                  <span>Add Quick Pizza</span>
+                </Button>
+                <Link href="/constructor">
+                  <Button variant="outline" size="sm" className="text-xs">
+                    <Sparkles className="w-3.5 h-3.5 mr-1 text-[#f39c12]" />
+                    <span>Custom Builder</span>
+                  </Button>
+                </Link>
+              </div>
+            )}
+          </div>
+
+          {/* Quick Add Modal */}
+          {isQuickAddOpen && (
+            <div className="bg-[#1a252f] border-2 border-[#f39c12] rounded-3xl p-5 shadow-2xl space-y-4 animate-in fade-in zoom-in duration-200">
+              <div className="flex items-center justify-between border-b border-[#34495e]/60 pb-2">
+                <h3 className="text-sm font-bold text-[#ecf0f1]">
+                  Select Pizza to Add to Your Share
+                </h3>
+                <button
+                  onClick={() => setIsQuickAddOpen(false)}
+                  className="text-xs text-[#7f8c8d] hover:text-[#ecf0f1]"
+                >
+                  Cancel
+                </button>
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+                {QUICK_MENU_ITEMS.map((item) => (
+                  <button
+                    key={item.name}
+                    type="button"
+                    onClick={() => handleQuickAdd(item)}
+                    className="p-3 rounded-xl bg-[#0f171e] border border-[#34495e] hover:border-[#f39c12] text-left flex items-center justify-between transition-all group"
+                  >
+                    <div>
+                      <div className="text-xs font-bold text-[#ecf0f1] group-hover:text-[#f39c12]">
+                        {item.name}
+                      </div>
+                      <div className="text-[10px] text-[#7f8c8d]">{item.size}</div>
+                    </div>
+                    <span className="text-xs font-extrabold text-[#f39c12] font-mono">
+                      ${item.price.toFixed(2)}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Items by Participant */}
+          {Object.keys(itemsByParticipant).length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-20 text-center rounded-3xl bg-[#1a252f]/40 border border-[#34495e]/40 p-8 space-y-3">
+              <ShoppingBag className="w-12 h-12 text-[#7f8c8d]" />
+              <h3 className="text-base font-bold text-[#ecf0f1]">
+                No items added to the group order yet
+              </h3>
+              <p className="text-xs text-[#95a5a6] max-w-sm">
+                Click &ldquo;Add Quick Pizza&rdquo; or create a custom recipe in the Pizza Constructor to add items under your name.
+              </p>
+            </div>
+          ) : (
+            Object.entries(itemsByParticipant).map(([name, participantItems]) => {
+              const subtotal = participantItems.reduce((s, i) => s + i.unitPrice * i.quantity, 0);
+
+              return (
+                <div
+                  key={name}
+                  className="bg-[#1a252f] border border-[#34495e]/70 rounded-3xl p-5 shadow-xl space-y-3"
+                >
+                  <div className="flex items-center justify-between border-b border-[#34495e]/50 pb-2.5">
+                    <div className="flex items-center space-x-2">
+                      <div className="w-7 h-7 rounded-full bg-[#f39c12]/20 border border-[#f39c12]/50 flex items-center justify-center text-xs font-black text-[#f39c12]">
+                        {name.charAt(0).toUpperCase()}
+                      </div>
+                      <span className="text-sm font-bold text-[#ecf0f1] font-display">
+                        {name}&rsquo;s Selection
+                      </span>
+                    </div>
+                    <span className="text-xs font-extrabold text-[#f39c12] font-mono">
+                      ${subtotal.toFixed(2)}
+                    </span>
+                  </div>
+
+                  <div className="divide-y divide-[#34495e]/40">
+                    {participantItems.map((item) => (
+                      <div
+                        key={item.id}
+                        className="py-2.5 flex items-center justify-between text-xs"
+                      >
+                        <div>
+                          <div className="font-semibold text-[#ecf0f1]">
+                            {item.quantity}x {item.name}
+                          </div>
+                          <div className="text-[10px] text-[#7f8c8d]">
+                            {item.sizeLabel} • {item.weightG}g
+                          </div>
+                        </div>
+
+                        <div className="flex items-center space-x-3">
+                          <span className="font-mono font-bold text-[#f39c12]">
+                            ${(item.unitPrice * item.quantity).toFixed(2)}
+                          </span>
+
+                          {(name === currentParticipant?.name || isHost) && room?.status === "open" && (
+                            <button
+                              type="button"
+                              onClick={() => removeItem(item.id)}
+                              className="text-[#7f8c8d] hover:text-[#e74c3c] transition-colors p-1"
+                            >
+                              <Trash2 className="w-3.5 h-3.5" />
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {/* RIGHT COLUMN: Host Moderation & Summary Checkout */}
+        <div className="lg:col-span-4 space-y-6">
+          <div className="bg-[#1a252f] border border-[#34495e]/80 rounded-3xl p-6 shadow-2xl space-y-5">
+            <h3 className="text-base font-bold text-[#ecf0f1] font-display border-b border-[#34495e]/60 pb-3">
+              Group Summary
+            </h3>
+
+            <div className="space-y-2 text-xs">
+              <div className="flex items-center justify-between text-[#95a5a6]">
+                <span>Total Items</span>
+                <span className="font-mono text-[#ecf0f1]">{totalGroupCount} pizzas/items</span>
+              </div>
+              <div className="flex items-center justify-between text-[#95a5a6]">
+                <span>Total Participants</span>
+                <span className="font-mono text-[#ecf0f1]">{room?.participants.length || 0}</span>
+              </div>
+              <div className="flex items-center justify-between text-[#95a5a6]">
+                <span>Delivery</span>
+                <span className="text-[#27ae60] font-bold">FREE (Group Order)</span>
+              </div>
+
+              <div className="pt-3 border-t border-[#34495e]/60 flex items-center justify-between font-bold text-sm">
+                <span className="text-[#ecf0f1]">Aggregated Total</span>
+                <span className="text-2xl font-extrabold text-[#f39c12] font-display">
+                  ${totalGroupPrice.toFixed(2)}
+                </span>
+              </div>
+            </div>
+
+            {/* Host Controls */}
+            {isHost && (
+              <div className="pt-3 border-t border-[#34495e]/60 space-y-2.5">
+                <span className="text-[10px] uppercase font-extrabold text-[#f39c12] tracking-wider block">
+                  Host Moderation Panel
+                </span>
+
+                {room?.status === "open" ? (
+                  <Button
+                    variant="secondary"
+                    size="md"
+                    onClick={() => setStatus("locked")}
+                    className="w-full flex items-center justify-center text-xs font-bold border border-[#f39c12]/40"
+                  >
+                    <Lock className="w-3.5 h-3.5 mr-1.5 text-[#f39c12]" />
+                    <span>Lock Session (Stop Edits)</span>
+                  </Button>
+                ) : (
+                  <Button
+                    variant="outline"
+                    size="md"
+                    onClick={() => setStatus("open")}
+                    className="w-full flex items-center justify-center text-xs font-bold text-[#27ae60] border-[#27ae60]/40"
+                  >
+                    <Unlock className="w-3.5 h-3.5 mr-1.5 text-[#27ae60]" />
+                    <span>Re-Open Session</span>
+                  </Button>
+                )}
+
+                <Button
+                  variant="primary"
+                  size="lg"
+                  disabled={totalGroupCount === 0}
+                  onClick={() => {
+                    setStatus("submitted");
+                    router.push("/cart");
+                  }}
+                  className="w-full flex items-center justify-center font-extrabold text-sm shadow-xl shadow-[#f39c12]/20"
+                >
+                  <span>Place Final Group Checkout (${totalGroupPrice.toFixed(2)})</span>
+                  <ArrowRight className="w-4 h-4 ml-1.5" />
+                </Button>
+              </div>
+            )}
+
+            {!isHost && (
+              <div className="p-3 rounded-xl bg-[#0f171e] border border-[#34495e] text-center">
+                <span className="text-xs text-[#95a5a6]">
+                  {room?.status === "open"
+                    ? "Add your pizzas! The host will checkout once the timer expires."
+                    : "Room is locked. Waiting for host to finalize order."}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/group-order/create/page.tsx
+++ b/apps/web/src/app/group-order/create/page.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import {
+  Users,
+  Clock,
+  MapPin,
+  Sparkles,
+  ArrowRight,
+  ShieldCheck,
+  User,
+  UtensilsCrossed,
+} from "lucide-react";
+import { Button } from "@pizzaconstructor/ui";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
+export default function CreateGroupOrderPage() {
+  const router = useRouter();
+
+  const [title, setTitle] = React.useState("");
+  const [hostName, setHostName] = React.useState("");
+  const [durationMinutes, setDurationMinutes] = React.useState<number>(60); // default 1 hr
+  const [deliveryAddress, setDeliveryAddress] = React.useState("");
+  const [maxParticipants, setMaxParticipants] = React.useState<number>(20);
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [errorMsg, setErrorMsg] = React.useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim() || !hostName.trim()) return;
+
+    setIsSubmitting(true);
+    setErrorMsg(null);
+
+    const deadlineIso =
+      durationMinutes > 0
+        ? new Date(Date.now() + durationMinutes * 60 * 1000).toISOString()
+        : undefined;
+
+    try {
+      const res = await fetch(`${API_BASE}/api/group-orders`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          hostName: hostName.trim(),
+          deadlineIso,
+          deliveryAddress: deliveryAddress.trim() || undefined,
+          maxParticipants,
+        }),
+      });
+
+      const data = await res.json();
+      if (data.success && data.roomId) {
+        // Save host token and host participant
+        if (data.hostToken) {
+          localStorage.setItem(`host-token-${data.roomId}`, data.hostToken);
+        }
+        if (data.room?.participants?.[0]) {
+          localStorage.setItem(
+            `participant-${data.roomId}`,
+            JSON.stringify(data.room.participants[0])
+          );
+        }
+
+        router.push(`/group-order/${data.roomId}`);
+      } else {
+        setErrorMsg(data.error || "Failed to create group order room");
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Network error creating room";
+      setErrorMsg(msg);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-16 flex-1 w-full">
+      {/* Header */}
+      <div className="text-center space-y-2 mb-8">
+        <div className="inline-flex items-center space-x-2 px-3 py-1 rounded-full bg-[#3498db]/15 border border-[#3498db]/30 text-[#3498db] text-xs font-bold uppercase tracking-wider mb-1">
+          <Users className="w-3.5 h-3.5" />
+          <span>Collaborative Session</span>
+        </div>
+        <h1 className="text-3xl sm:text-4xl font-extrabold text-[#ecf0f1] font-display tracking-tight">
+          Create a <span className="text-[#f39c12]">Group Order</span>
+        </h1>
+        <p className="text-sm text-[#95a5a6] max-w-lg mx-auto">
+          Start a shared order room, share the invitation link with colleagues or friends, aggregate carts, and place one combined order.
+        </p>
+      </div>
+
+      {/* Form Card */}
+      <form
+        onSubmit={handleSubmit}
+        className="bg-[#1a252f] border border-[#34495e]/80 rounded-3xl p-6 sm:p-8 shadow-2xl space-y-6"
+      >
+        {errorMsg && (
+          <div className="p-3.5 rounded-xl bg-[#e74c3c]/15 border border-[#e74c3c]/30 text-xs text-[#e74c3c] font-medium">
+            {errorMsg}
+          </div>
+        )}
+
+        {/* Room Title */}
+        <div className="space-y-1.5">
+          <label className="text-xs font-bold text-[#7f8c8d] uppercase tracking-wider flex items-center space-x-1">
+            <UtensilsCrossed className="w-3.5 h-3.5 text-[#f39c12]" />
+            <span>Group Order Name *</span>
+          </label>
+          <input
+            type="text"
+            required
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="E.g., Friday Office Pizza Feast 🍕"
+            className="w-full px-4 py-3 rounded-xl bg-[#0f171e] border border-[#34495e] text-sm font-semibold text-[#ecf0f1] focus:outline-none focus:border-[#f39c12] transition-colors"
+          />
+        </div>
+
+        {/* Host Name */}
+        <div className="space-y-1.5">
+          <label className="text-xs font-bold text-[#7f8c8d] uppercase tracking-wider flex items-center space-x-1">
+            <User className="w-3.5 h-3.5 text-[#f39c12]" />
+            <span>Your Name (Host) *</span>
+          </label>
+          <input
+            type="text"
+            required
+            value={hostName}
+            onChange={(e) => setHostName(e.target.value)}
+            placeholder="John Silver"
+            className="w-full px-4 py-3 rounded-xl bg-[#0f171e] border border-[#34495e] text-sm font-semibold text-[#ecf0f1] focus:outline-none focus:border-[#f39c12] transition-colors"
+          />
+        </div>
+
+        {/* Deadline Duration */}
+        <div className="space-y-2">
+          <label className="text-xs font-bold text-[#7f8c8d] uppercase tracking-wider flex items-center space-x-1">
+            <Clock className="w-3.5 h-3.5 text-[#f39c12]" />
+            <span>Order Deadline Duration</span>
+          </label>
+          <div className="grid grid-cols-4 gap-2">
+            {[
+              { mins: 30, label: "30 Mins" },
+              { mins: 60, label: "1 Hour" },
+              { mins: 120, label: "2 Hours" },
+              { mins: 0, label: "No Timer" },
+            ].map((opt) => {
+              const isSelected = durationMinutes === opt.mins;
+              return (
+                <button
+                  key={opt.mins}
+                  type="button"
+                  onClick={() => setDurationMinutes(opt.mins)}
+                  className={`py-2.5 px-2 rounded-xl border text-center text-xs font-bold transition-all ${
+                    isSelected
+                      ? "bg-[#f39c12]/20 border-[#f39c12] text-[#f39c12] shadow-sm"
+                      : "bg-[#0f171e] border-[#34495e] text-[#95a5a6] hover:text-[#ecf0f1]"
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Delivery Address & Max Seats */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="space-y-1.5">
+            <label className="text-xs font-bold text-[#7f8c8d] uppercase tracking-wider flex items-center space-x-1">
+              <MapPin className="w-3.5 h-3.5 text-[#f39c12]" />
+              <span>Delivery Destination (Optional)</span>
+            </label>
+            <input
+              type="text"
+              value={deliveryAddress}
+              onChange={(e) => setDeliveryAddress(e.target.value)}
+              placeholder="Building A, 5th Floor Lounge"
+              className="w-full px-4 py-2.5 rounded-xl bg-[#0f171e] border border-[#34495e] text-xs font-medium text-[#ecf0f1] focus:outline-none focus:border-[#f39c12]"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-xs font-bold text-[#7f8c8d] uppercase tracking-wider flex items-center space-x-1">
+              <Users className="w-3.5 h-3.5 text-[#f39c12]" />
+              <span>Max Participants</span>
+            </label>
+            <input
+              type="number"
+              min={2}
+              max={100}
+              value={maxParticipants}
+              onChange={(e) => setMaxParticipants(parseInt(e.target.value) || 20)}
+              className="w-full px-4 py-2.5 rounded-xl bg-[#0f171e] border border-[#34495e] text-xs font-medium text-[#ecf0f1] focus:outline-none focus:border-[#f39c12]"
+            />
+          </div>
+        </div>
+
+        {/* Action Button */}
+        <div className="pt-4 space-y-3">
+          <Button
+            type="submit"
+            variant="primary"
+            size="lg"
+            disabled={isSubmitting}
+            className="w-full flex items-center justify-center font-extrabold text-sm shadow-xl shadow-[#f39c12]/20"
+          >
+            {isSubmitting ? (
+              <span>Initializing Room...</span>
+            ) : (
+              <>
+                <Sparkles className="w-4 h-4 mr-2 text-[#0f171e]" />
+                <span>Launch Group Order Room</span>
+                <ArrowRight className="w-4 h-4 ml-2 text-[#0f171e]" />
+              </>
+            )}
+          </Button>
+
+          <div className="flex items-center justify-center space-x-2 text-[11px] text-[#7f8c8d]">
+            <ShieldCheck className="w-3.5 h-3.5 text-[#27ae60]" />
+            <span>Host credentials will be saved securely to this browser</span>
+          </div>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/apps/web/src/app/group-order/page.tsx
+++ b/apps/web/src/app/group-order/page.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import {
+  Users,
+  Sparkles,
+  Plus,
+  ArrowRight,
+  Clock,
+  CheckCircle2,
+  Layers,
+} from "lucide-react";
+import { Button } from "@pizzaconstructor/ui";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
+interface GroupRoomSummary {
+  id: string;
+  title: string;
+  hostName: string;
+  status: string;
+  deadlineIso?: string;
+  participantsCount: number;
+  itemsCount: number;
+  totalPrice: number;
+  createdAt: string;
+}
+
+export default function GroupOrdersDirectoryPage() {
+  const [rooms, setRooms] = React.useState<GroupRoomSummary[]>([]);
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    fetch(`${API_BASE}/api/group-orders`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.success && data.rooms) {
+          setRooms(data.rooms);
+        }
+      })
+      .catch((err) => {
+        console.warn("Could not load group order rooms:", err);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  return (
+    <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12 flex-1 w-full space-y-12">
+      {/* Hero Section */}
+      <div className="relative rounded-3xl bg-gradient-to-r from-[#1a252f] via-[#2c3e50] to-[#1a252f] border border-[#34495e]/80 p-8 sm:p-12 overflow-hidden shadow-2xl">
+        <div className="max-w-2xl space-y-4">
+          <div className="inline-flex items-center space-x-2 px-3 py-1 rounded-full bg-[#f39c12]/20 border border-[#f39c12]/30 text-[#f39c12] text-xs font-bold uppercase tracking-wider">
+            <Users className="w-3.5 h-3.5" />
+            <span>Collaborative Ordering Studio</span>
+          </div>
+
+          <h1 className="text-3xl sm:text-5xl font-extrabold text-[#ecf0f1] font-display tracking-tight leading-tight">
+            Order Pizza <span className="text-[#f39c12]">Together</span> with Your Team
+          </h1>
+
+          <p className="text-sm sm:text-base text-[#bdc3c7] leading-relaxed">
+            No more messy group chats or calculating who owes what. Create a collaborative room, share the link, watch the cart update live, and place one combined order.
+          </p>
+
+          <div className="pt-2 flex flex-wrap items-center gap-3">
+            <Link href="/group-order/create">
+              <Button variant="primary" size="lg" className="font-extrabold shadow-xl shadow-[#f39c12]/20 text-sm">
+                <Plus className="w-4 h-4 mr-1.5" />
+                <span>Create Group Room</span>
+              </Button>
+            </Link>
+            <Link href="/constructor">
+              <Button variant="outline" size="lg" className="text-xs">
+                <Sparkles className="w-4 h-4 mr-1.5 text-[#f39c12]" />
+                <span>Build Pizza First</span>
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      {/* Active Public Rooms */}
+      <div className="space-y-4">
+        <div className="flex items-center justify-between border-b border-[#34495e]/60 pb-3">
+          <div>
+            <h2 className="text-xl font-bold text-[#ecf0f1] font-display">
+              Active Group Order Sessions
+            </h2>
+            <p className="text-xs text-[#95a5a6]">
+              Join an open room or start your own custom session.
+            </p>
+          </div>
+          <Link href="/group-order/create">
+            <Button variant="outline" size="sm" className="text-xs">
+              <Plus className="w-3.5 h-3.5 mr-1" />
+              <span>New Room</span>
+            </Button>
+          </Link>
+        </div>
+
+        {loading ? (
+          <div className="py-16 text-center text-sm text-[#95a5a6]">
+            Loading active sessions...
+          </div>
+        ) : rooms.length === 0 ? (
+          <div className="py-16 text-center rounded-3xl bg-[#1a252f]/40 border border-[#34495e]/40 p-8 space-y-3">
+            <Layers className="w-12 h-12 text-[#7f8c8d] mx-auto" />
+            <h3 className="text-base font-bold text-[#ecf0f1]">No active public rooms</h3>
+            <p className="text-xs text-[#95a5a6]">Be the first to start a group pizza party today!</p>
+            <Link href="/group-order/create">
+              <Button variant="primary" size="sm" className="font-bold text-xs">
+                Launch Room
+              </Button>
+            </Link>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {rooms.map((room) => (
+              <div
+                key={room.id}
+                className="bg-[#1a252f] border border-[#34495e]/70 hover:border-[#f39c12]/60 rounded-3xl p-6 shadow-xl flex flex-col justify-between space-y-4 transition-all group"
+              >
+                <div>
+                  <div className="flex items-center justify-between">
+                    <span className="px-2.5 py-0.5 rounded-full text-[10px] font-extrabold uppercase tracking-wider bg-[#27ae60]/15 text-[#27ae60] border border-[#27ae60]/30">
+                      {room.status}
+                    </span>
+                    <span className="text-xs font-mono font-bold text-[#f39c12]">
+                      ${room.totalPrice.toFixed(2)}
+                    </span>
+                  </div>
+
+                  <h3 className="text-lg font-bold text-[#ecf0f1] font-display mt-2 group-hover:text-[#f39c12] transition-colors">
+                    {room.title}
+                  </h3>
+
+                  <div className="flex items-center space-x-3 text-xs text-[#7f8c8d] mt-1.5">
+                    <span>Host: <strong className="text-[#ecf0f1]">{room.hostName}</strong></span>
+                    <span>•</span>
+                    <span>{room.participantsCount} participants</span>
+                  </div>
+                </div>
+
+                <div className="pt-3 border-t border-[#34495e]/50 flex items-center justify-between">
+                  <div className="text-xs text-[#95a5a6]">
+                    {room.itemsCount} items in cart
+                  </div>
+
+                  <Link href={`/group-order/${room.id}`}>
+                    <Button variant="primary" size="sm" className="text-xs font-bold">
+                      <span>Join Room</span>
+                      <ArrowRight className="w-3.5 h-3.5 ml-1" />
+                    </Button>
+                  </Link>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* How it works 3-Step Guide */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 pt-6">
+        <div className="bg-[#1a252f]/60 border border-[#34495e]/60 rounded-3xl p-6 space-y-2 text-center">
+          <div className="w-12 h-12 rounded-2xl bg-[#f39c12]/15 border border-[#f39c12]/30 flex items-center justify-center text-[#f39c12] mx-auto mb-3">
+            <Clock className="w-6 h-6" />
+          </div>
+          <h3 className="text-base font-bold text-[#ecf0f1]">1. Set Deadline Timer</h3>
+          <p className="text-xs text-[#95a5a6] leading-relaxed">
+            Choose how long your room stays open. Sessions automatically lock when the countdown expires.
+          </p>
+        </div>
+
+        <div className="bg-[#1a252f]/60 border border-[#34495e]/60 rounded-3xl p-6 space-y-2 text-center">
+          <div className="w-12 h-12 rounded-2xl bg-[#3498db]/15 border border-[#3498db]/30 flex items-center justify-center text-[#3498db] mx-auto mb-3">
+            <Users className="w-6 h-6" />
+          </div>
+          <h3 className="text-base font-bold text-[#ecf0f1]">2. Invite with 1-Click</h3>
+          <p className="text-xs text-[#95a5a6] leading-relaxed">
+            Copy the invite link and drop it into Slack, Teams, or WhatsApp. Everyone adds their own items.
+          </p>
+        </div>
+
+        <div className="bg-[#1a252f]/60 border border-[#34495e]/60 rounded-3xl p-6 space-y-2 text-center">
+          <div className="w-12 h-12 rounded-2xl bg-[#27ae60]/15 border border-[#27ae60]/30 flex items-center justify-center text-[#27ae60] mx-auto mb-3">
+            <CheckCircle2 className="w-6 h-6" />
+          </div>
+          <h3 className="text-base font-bold text-[#ecf0f1]">3. Unified Kitchen Delivery</h3>
+          <p className="text-xs text-[#95a5a6] leading-relaxed">
+            The host places one unified order. All pizzas arrive freshly baked together with free group delivery.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/hooks/useGroupOrderWs.ts
+++ b/apps/web/src/hooks/useGroupOrderWs.ts
@@ -1,0 +1,202 @@
+"use client";
+
+import * as React from "react";
+import type {
+  GroupOrderRoom,
+  GroupParticipant,
+  GroupOrderItem,
+  GroupOrderStatus,
+  GroupWsMessage,
+} from "@pizzaconstructor/shared";
+
+interface UseGroupOrderWsReturn {
+  room: GroupOrderRoom | null;
+  currentParticipant: GroupParticipant | null;
+  isConnected: boolean;
+  isHost: boolean;
+  joinRoom: (name: string, avatar?: string) => void;
+  addItem: (item: Omit<GroupOrderItem, "id" | "createdAt" | "participantId" | "participantName">) => void;
+  removeItem: (itemId: string) => void;
+  setStatus: (status: GroupOrderStatus) => void;
+  leaveRoom: () => void;
+}
+
+export function useGroupOrderWs(roomId: string): UseGroupOrderWsReturn {
+  const [room, setRoom] = React.useState<GroupOrderRoom | null>(null);
+  const [currentParticipant, setCurrentParticipant] = React.useState<GroupParticipant | null>(null);
+  const [isConnected, setIsConnected] = React.useState(false);
+  const socketRef = React.useRef<WebSocket | null>(null);
+
+  // Check stored hostToken or participantId from localStorage
+  const getStoredHostToken = React.useCallback(() => {
+    if (typeof window === "undefined") return undefined;
+    return localStorage.getItem(`host-token-${roomId}`) || undefined;
+  }, [roomId]);
+
+  const getStoredParticipant = React.useCallback(() => {
+    if (typeof window === "undefined") return null;
+    const raw = localStorage.getItem(`participant-${roomId}`);
+    if (raw) {
+      try {
+        return JSON.parse(raw) as GroupParticipant;
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }, [roomId]);
+
+  React.useEffect(() => {
+    const savedP = getStoredParticipant();
+    if (savedP) {
+      setCurrentParticipant(savedP);
+    }
+  }, [getStoredParticipant]);
+
+  React.useEffect(() => {
+    if (!roomId) return;
+
+    const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    // API port 3001
+    const wsHost = process.env.NEXT_PUBLIC_API_WS_URL || `${wsProtocol}//${window.location.hostname}:3001`;
+    const wsUrl = `${wsHost}/ws/group-orders/${roomId}`;
+
+    const ws = new WebSocket(wsUrl);
+    socketRef.current = ws;
+
+    ws.onopen = () => {
+      setIsConnected(true);
+      const savedP = getStoredParticipant();
+      if (savedP) {
+        // Auto rejoin
+        ws.send(
+          JSON.stringify({
+            type: "JOIN_ROOM",
+            roomId,
+            payload: { participantName: savedP.name, avatar: savedP.avatar },
+          })
+        );
+      }
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data) as GroupWsMessage;
+        if (msg.type === "ROOM_SYNC") {
+          const payload = msg.payload as {
+            room?: GroupOrderRoom;
+            yourParticipant?: GroupParticipant;
+            joinedParticipant?: GroupParticipant;
+          };
+          if (payload?.room) {
+            setRoom(payload.room);
+          }
+          if (payload?.yourParticipant) {
+            setCurrentParticipant(payload.yourParticipant);
+            localStorage.setItem(`participant-${roomId}`, JSON.stringify(payload.yourParticipant));
+          }
+        }
+      } catch (err) {
+        console.warn("WebSocket parse error:", err);
+      }
+    };
+
+    ws.onclose = () => {
+      setIsConnected(false);
+    };
+
+    return () => {
+      ws.close();
+    };
+  }, [roomId, getStoredParticipant]);
+
+  const isHost = React.useMemo(() => {
+    if (!room || !currentParticipant) return false;
+    const hostToken = getStoredHostToken();
+    return currentParticipant.isHost || (!!hostToken && hostToken === room.hostToken);
+  }, [room, currentParticipant, getStoredHostToken]);
+
+  const joinRoom = (name: string, avatar?: string) => {
+    if (!socketRef.current || socketRef.current.readyState !== WebSocket.OPEN) return;
+    socketRef.current.send(
+      JSON.stringify({
+        type: "JOIN_ROOM",
+        roomId,
+        payload: { participantName: name, avatar },
+      })
+    );
+  };
+
+  const addItem = (
+    item: Omit<GroupOrderItem, "id" | "createdAt" | "participantId" | "participantName">
+  ) => {
+    if (!socketRef.current || !currentParticipant) return;
+    socketRef.current.send(
+      JSON.stringify({
+        type: "ADD_ITEM",
+        roomId,
+        payload: {
+          ...item,
+          participantId: currentParticipant.id,
+          participantName: currentParticipant.name,
+        },
+      })
+    );
+  };
+
+  const removeItem = (itemId: string) => {
+    if (!socketRef.current) return;
+    const hostToken = getStoredHostToken();
+    socketRef.current.send(
+      JSON.stringify({
+        type: "REMOVE_ITEM",
+        roomId,
+        payload: {
+          itemId,
+          participantId: currentParticipant?.id,
+          hostToken,
+        },
+      })
+    );
+  };
+
+  const setStatus = (status: GroupOrderStatus) => {
+    if (!socketRef.current) return;
+    const hostToken = getStoredHostToken();
+    socketRef.current.send(
+      JSON.stringify({
+        type: "SET_STATUS",
+        roomId,
+        payload: {
+          status,
+          hostToken,
+        },
+      })
+    );
+  };
+
+  const leaveRoom = () => {
+    if (!socketRef.current || !currentParticipant) return;
+    socketRef.current.send(
+      JSON.stringify({
+        type: "LEAVE_ROOM",
+        roomId,
+        payload: { participantId: currentParticipant.id },
+      })
+    );
+    localStorage.removeItem(`participant-${roomId}`);
+    setCurrentParticipant(null);
+  };
+
+  return {
+    room,
+    currentParticipant,
+    isConnected,
+    isHost,
+    joinRoom,
+    addItem,
+    removeItem,
+    setStatus,
+    leaveRoom,
+  };
+}


### PR DESCRIPTION
## Summary of Changes
- Built real-time `useGroupOrderWs` hook in `apps/web` supporting seamless session syncing and actions.
- Created Group Order Creation Studio at `/group-order/create`.
- Implemented collaborative Group Order Room at `/group-order/[slug]` with:
  - Live deadline countdown timer with visual alerts.
  - 1-click shareable invite link copy button.
  - Active participant roster chips with Host indicators.
  - Multi-user cart stream grouped by participant with individual subtotals.
  - Quick-add pizza modal.
  - Host moderation panel (lock/unlock session & group checkout).
- Created public Group Orders Directory at `/group-order`.

## Connected Work Item
Closes #51

## Verification & Test Results
- `turbo check-types`: 5/5 tasks passed (0 errors)
- `turbo lint`: 5/5 tasks passed (0 errors)
- `turbo build`: 2/2 tasks passed (`apps/api` and `apps/web` compiled cleanly)